### PR TITLE
configurable bcrypt_log_rounds and pbkdf2_rounds

### DIFF
--- a/lib/comeonin/bcrypt.ex
+++ b/lib/comeonin/bcrypt.ex
@@ -13,9 +13,9 @@ defmodule Comeonin.Bcrypt do
   """
 
   alias Comeonin.Tools
+  alias Comeonin.Config
 
   @on_load {:init, 0}
-  @log_rounds 12
 
   def init do
     path = :filename.join(:code.priv_dir(:comeonin), 'bcrypt_nif')
@@ -32,8 +32,8 @@ defmodule Comeonin.Bcrypt do
   def gen_salt(log_rounds) when is_integer(log_rounds) do
     :crypto.rand_bytes(16) |> encode_salt(log_rounds)
   end
-  def gen_salt(_), do: gen_salt(@log_rounds)
-  def gen_salt, do: gen_salt(@log_rounds)
+  def gen_salt(_), do: gen_salt(Config.bcrypt_log_rounds)
+  def gen_salt, do: gen_salt(Config.bcrypt_log_rounds)
 
   defp encode_salt(_rand_num, _log_rounds) do
     exit(:nif_library_not_loaded)
@@ -66,7 +66,7 @@ defmodule Comeonin.Bcrypt do
   There is an option to change the log_rounds parameter, which
   affects the complexity of the generation of the salt.
   """
-  def hashpwsalt(password, log_rounds \\ @log_rounds) do
+  def hashpwsalt(password, log_rounds \\ Config.bcrypt_log_rounds) do
     salt = gen_salt(log_rounds)
     hashpass(password, salt)
   end

--- a/lib/comeonin/config.ex
+++ b/lib/comeonin/config.ex
@@ -1,0 +1,19 @@
+defmodule Comeonin.Config do
+  @moduledoc """
+  This module provides abstraction layer for configuration.
+  Followings are valid configuration items.
+
+  | name               | type    | default |
+  | :----------------- | :------ | ------: |
+  | bcrypt_log_rounds  | integer | 12      |
+  | pbkdf2_rounds      | integer | 60000   |
+  """
+
+  def bcrypt_log_rounds do
+    Application.get_env(:comeonin, :bcrypt_log_rounds, 12)
+  end
+
+  def pbkdf2_rounds do
+    Application.get_env(:comeonin, :pbkdf2_rounds, 60_000)
+  end
+end

--- a/lib/comeonin/pbkdf2.ex
+++ b/lib/comeonin/pbkdf2.ex
@@ -11,9 +11,9 @@ defmodule Comeonin.Pbkdf2 do
 
   use Bitwise
   alias Comeonin.Tools
+  alias Comeonin.Config
 
   @max_length bsl(1, 32) - 1
-  @rounds 60_000
   @salt_length 16
 
   @doc """
@@ -33,15 +33,15 @@ defmodule Comeonin.Pbkdf2 do
   @doc """
   Hash the password using pbkdf2_sha512.
   """
-  def hashpass(password, salt, rounds \\ @rounds) do
+  def hashpass(password, salt, rounds \\ Config.pbkdf2_rounds) do
     pbkdf2(password, salt, rounds, 64) |> format(salt, rounds)
   end
 
   @doc """
   Hash the password with a salt which is randomly generated.
   """
-  def hashpwsalt(password, rounds \\ @rounds) do
-    salt = gen_salt(@salt_length)
+  def hashpwsalt(password, rounds \\ Config.pbkdf2_rounds) do
+    salt = gen_salt
     hashpass(password, salt, rounds)
   end
 

--- a/test/bcrypt_test.exs
+++ b/test/bcrypt_test.exs
@@ -105,4 +105,12 @@ defmodule Comeonin.BcryptTest do
       Bcrypt.hashpass(["U*U"], "$2a$05$CCCCCCCCCCCCCCCCCCCCC.")
     end
   end
+
+  test "bcrypt_log_rounds configuration" do
+    prefix = '$2b$10$'
+    Application.put_env(:comeonin, :bcrypt_log_rounds, 10)
+    assert :lists.prefix(prefix, Bcrypt.gen_salt)
+    assert String.starts_with?(Bcrypt.hashpwsalt("password"), to_string(prefix))
+    Application.delete_env(:comeonin, :bcrypt_log_rounds)
+  end
 end

--- a/test/pbkdf2_test.exs
+++ b/test/pbkdf2_test.exs
@@ -79,4 +79,12 @@ defmodule Comeonin.Pbkdf2Test do
       Pbkdf2.gen_salt(1025)
     end
   end
+
+  test "pbkdf2_rounds configuration" do
+    prefix = "$pbkdf2-sha512$12000$"
+    Application.put_env(:comeonin, :pbkdf2_rounds, 12_000)
+    assert String.starts_with?(Pbkdf2.hashpass("password", Pbkdf2.gen_salt), prefix)
+    assert String.starts_with?(Pbkdf2.hashpwsalt("password"), prefix)
+    Application.delete_env(:comeonin, :pbkdf2_rounds)
+  end
 end


### PR DESCRIPTION
Hi, I'm using comeoin on phoenix project and I'd like to change `log_rounds` depends on `Mix.env`.
For example only in production `log_rounds = 20`, else `log_rounds = 4` especially in test.

So I made these rounds value be configurable via config.exs like below.

```elixir
config :comeonin,
  bcrypt_log_rounds: 8,
  pbkdf2_rounds: 10_000
```
Their default values are not changed, 12 and 60000, respectively.

Thanks. :smiley: 