### PR TITLE
Scheduler-friendly bcrypt NIF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ NIF_SRC=\
 
 all: comeonin
 
-priv/bcrypt_nif.so:
+priv/bcrypt_nif.so: $(NIF_SRC)
 	$(CC) $(CFLAGS) -shared $(LDFLAGS) -o $@ $(NIF_SRC)
 
 comeonin:

--- a/c_src/bcrypt.c
+++ b/c_src/bcrypt.c
@@ -63,6 +63,8 @@
 
 static int encode_base64(char *, const u_int8_t *, size_t);
 static int decode_base64(u_int8_t *, size_t, const char *);
+static ERL_NIF_TERM bcrypt_expandstate(ErlNifEnv *, int, const ERL_NIF_TERM *);
+static ERL_NIF_TERM bcrypt_fini(ErlNifEnv *, int, const ERL_NIF_TERM *);
 static void secure_bzero(void *, size_t);
 
 static const u_int8_t Base64Code[] =
@@ -190,29 +192,23 @@ encode_salt(char *salt, size_t saltbuflen, uint8_t *csalt, uint16_t clen,
  * initialization routine for the bcrypt algorithm
  */
 ERL_NIF_TERM
-bcrypt_init(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+bcrypt(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
-	blf_ctx state;
-	u_int32_t rounds, i, k;
-	u_int16_t j;
+	ErlNifBinary state;
+	u_int32_t rounds;
 	size_t key_len;
-	u_int8_t salt_len, logr, minor;
-	u_int8_t ciphertext[4 * BCRYPT_WORDS] = "OrpheanBeholderScryDoubt";
-	u_int8_t csalt[BCRYPT_MAXSALT];
-	u_int32_t cdata[BCRYPT_WORDS];
+	u_int8_t logr, minor;
+	ErlNifBinary csalt;
 	char key[1024];
 	char saltbuf[1024];
 	const char *salt = saltbuf;
-	char encrypted[BCRYPT_HASHSPACE];
-	size_t encryptedlen = sizeof(encrypted);
+	ERL_NIF_TERM newargv[7];
 
 	if (argc != 2) {
 		goto inval;
 	}
 
 	/* Get our password and salt from argv */
-	(void)memset(&key, '\0', sizeof(key));
-	(void)memset(&saltbuf, '\0', sizeof(saltbuf));
 	if (!enif_get_string(env, argv[0], key, sizeof(key), ERL_NIF_LATIN1)) {
 		goto inval;
 	}
@@ -220,9 +216,6 @@ bcrypt_init(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 				ERL_NIF_LATIN1)) {
 		goto inval;
 	}
-
-	if (encryptedlen < BCRYPT_HASHSPACE)
-		goto inval;
 
 	/* Check and discard "$" identifier */
 	if (salt[0] != '$')
@@ -272,20 +265,115 @@ bcrypt_init(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 		goto inval;
 
 	/* We dont want the base64 salt but the raw data */
-	if (decode_base64(csalt, BCRYPT_MAXSALT, salt))
+	if (!enif_alloc_binary(BCRYPT_MAXSALT, &csalt))
 		goto inval;
-	salt_len = BCRYPT_MAXSALT;
+	if (decode_base64((u_int8_t *)csalt.data, csalt.size, salt))
+		goto inval_release_csalt;
 
 	/* Setting up S-Boxes and Subkeys */
-	Blowfish_initstate(&state);
-	Blowfish_expandstate(&state, csalt, salt_len,
-	    (u_int8_t *) key, key_len);
+	if (!enif_alloc_binary(sizeof(blf_ctx), &state))
+		goto inval_release_csalt;
+	Blowfish_initstate((blf_ctx *) state.data);
+	Blowfish_expandstate((blf_ctx *) state.data, (u_int8_t *) csalt.data,
+			csalt.size, (u_int8_t *) key, key_len);
 
-	// FIXME This for-loop is the part that takes the most time.
-	for (k = 0; k < rounds; k++) {
-		Blowfish_expand0state(&state, (u_int8_t *) key, key_len);
-		Blowfish_expand0state(&state, csalt, salt_len);
+	/* Schedule key expansion */
+	newargv[0] = enif_make_binary(env, &state);
+	newargv[1] = enif_make_binary(env, &csalt);
+	newargv[2] = argv[0]; /* key variable */
+	newargv[3] = enif_make_ulong(env, (unsigned long)key_len);
+	newargv[4] = enif_make_ulong(env, (unsigned long)rounds);
+	newargv[5] = enif_make_ulong(env, (unsigned long)minor);
+	newargv[6] = enif_make_ulong(env, (unsigned long)logr);
+	return enif_schedule_nif(env, "bcrypt_expandstate", 0,
+			bcrypt_expandstate, 7, newargv);
+
+inval_release_csalt:
+	enif_release_binary(&csalt);
+inval:
+	return enif_make_badarg(env);
+}
+
+/*
+ * expand the Blowfish key state
+ */
+static ERL_NIF_TERM
+bcrypt_expandstate(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+	u_int32_t k;
+	ErlNifBinary state, csalt;
+	unsigned long key_len_arg, rounds_arg, minor_arg, logr_arg;
+	char key[1024];
+	size_t key_len;
+	u_int32_t rounds;
+	ERL_NIF_TERM newargv[4];
+
+	/* Initialize our data from argv */
+	if (argc != 7 || !enif_inspect_binary(env, argv[0], &state))
+		return enif_make_badarg(env);
+	if (!enif_inspect_binary(env, argv[1], &csalt)) {
+		enif_release_binary(&state);
+		return enif_make_badarg(env);
 	}
+	if (!enif_get_string(env, argv[2], key, sizeof(key), ERL_NIF_LATIN1) ||
+	    !enif_get_ulong(env, argv[3], &key_len_arg) ||
+	    !enif_get_ulong(env, argv[4], &rounds_arg) ||
+	    !enif_get_ulong(env, argv[5], &minor_arg) ||
+	    !enif_get_ulong(env, argv[6], &logr_arg)) {
+		enif_release_binary(&state);
+		enif_release_binary(&csalt);
+		return enif_make_badarg(env);
+	}
+	key_len = (size_t)key_len_arg;
+	rounds = (u_int32_t)rounds_arg;
+
+	/* Expand state */
+	for (k = 0; k < rounds; k++) {
+		Blowfish_expand0state((blf_ctx *) state.data, (u_int8_t *) key,
+				key_len);
+		Blowfish_expand0state((blf_ctx *) state.data,
+				(u_int8_t *) csalt.data, csalt.size);
+	}
+
+	/* Schedule finalization routine */
+	newargv[0] = enif_make_binary(env, &state);
+	newargv[1] = enif_make_binary(env, &csalt);
+	newargv[2] = argv[5]; /* minor variable */
+	newargv[3] = argv[6]; /* logr variable */
+	return enif_schedule_nif(env, "bcrypt_fini", 0, bcrypt_fini, 4, newargv);
+}
+
+/*
+ * finalization routine for the bcrypt algorithm
+ * encrypt and return the new hash
+ */
+static ERL_NIF_TERM
+bcrypt_fini(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
+{
+	u_int32_t i, k;
+	u_int16_t j;
+	u_int8_t ciphertext[4 * BCRYPT_WORDS] = "OrpheanBeholderScryDoubt";
+	u_int32_t cdata[BCRYPT_WORDS];
+	char encrypted[BCRYPT_HASHSPACE];
+	ErlNifBinary state, csalt;
+	unsigned long minor_arg, logr_arg;
+	u_int8_t logr, minor;
+
+	/* Initialize our data from argv */
+	if (argc != 4 || !enif_inspect_binary(env, argv[0], &state))
+		return enif_make_badarg(env);
+	if (!enif_inspect_binary(env, argv[1], &csalt)) {
+		enif_release_binary(&state);
+		return enif_make_badarg(env);
+	}
+	if (!enif_get_ulong(env, argv[2], &minor_arg) ||
+	    !enif_get_ulong(env, argv[3], &logr_arg)) {
+		enif_release_binary(&state);
+		enif_release_binary(&csalt);
+		return enif_make_badarg(env);
+	}
+	minor = (u_int8_t)minor_arg;
+	logr = (u_int8_t)logr_arg;
 
 	/* This can be precomputed later */
 	j = 0;
@@ -294,7 +382,7 @@ bcrypt_init(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
 	/* Now do the encryption */
 	for (k = 0; k < 64; k++)
-		blf_enc(&state, cdata, BCRYPT_WORDS / 2);
+		blf_enc((blf_ctx *) state.data, cdata, BCRYPT_WORDS / 2);
 
 	for (i = 0; i < BCRYPT_WORDS; i++) {
 		ciphertext[4 * i + 3] = cdata[i] & 0xff;
@@ -306,18 +394,16 @@ bcrypt_init(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 		ciphertext[4 * i + 0] = cdata[i] & 0xff;
 	}
 
-
 	snprintf(encrypted, 8, "$2%c$%2.2u$", minor, logr);
-	encode_base64(encrypted + 7, csalt, BCRYPT_MAXSALT);
+	encode_base64(encrypted + 7, (const u_int8_t *) csalt.data, BCRYPT_MAXSALT);
 	encode_base64(encrypted + 7 + 22, ciphertext, 4 * BCRYPT_WORDS - 1);
-	secure_bzero(&state, sizeof(state));
+	secure_bzero(state.data, state.size);
+	enif_release_binary(&state);
 	secure_bzero(ciphertext, sizeof(ciphertext));
-	secure_bzero(csalt, sizeof(csalt));
+	secure_bzero(csalt.data, csalt.size);
+	enif_release_binary(&csalt);
 	secure_bzero(cdata, sizeof(cdata));
 	return enif_make_string(env, encrypted, ERL_NIF_LATIN1);
-
-inval:
-	return enif_make_badarg(env);
 }
 
 /*

--- a/c_src/bcrypt_nif.c
+++ b/c_src/bcrypt_nif.c
@@ -26,7 +26,7 @@
 #define BCRYPT_SALTSPACE	(7 + (BCRYPT_MAXSALT * 4 + 2) / 3 + 1)
 #define BCRYPT_HASHSPACE	61
 
-ERL_NIF_TERM bcrypt_init(ErlNifEnv *, int, const ERL_NIF_TERM *);
+ERL_NIF_TERM bcrypt(ErlNifEnv *, int, const ERL_NIF_TERM *);
 void encode_salt(char *, size_t, uint8_t *, uint16_t, int);
 
 static ERL_NIF_TERM erl_encode_salt(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
@@ -57,7 +57,7 @@ static ERL_NIF_TERM erl_encode_salt(ErlNifEnv* env, int argc, const ERL_NIF_TERM
 
 static ERL_NIF_TERM hashpw(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
-    return enif_schedule_nif(env, "bcrypt_init", 0, bcrypt_init, 2, argv);
+    return enif_schedule_nif(env, "bcrypt", 0, bcrypt, 2, argv);
 }
 
 static ErlNifFunc bcrypt_nif_funcs[] =

--- a/c_src/bcrypt_nif.c
+++ b/c_src/bcrypt_nif.c
@@ -26,7 +26,7 @@
 #define BCRYPT_SALTSPACE	(7 + (BCRYPT_MAXSALT * 4 + 2) / 3 + 1)
 #define BCRYPT_HASHSPACE	61
 
-int bcrypt(const char *, const char *, char *, size_t);
+ERL_NIF_TERM bcrypt_init(ErlNifEnv *, int, const ERL_NIF_TERM *);
 void encode_salt(char *, size_t, uint8_t *, uint16_t, int);
 
 static ERL_NIF_TERM erl_encode_salt(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
@@ -57,25 +57,7 @@ static ERL_NIF_TERM erl_encode_salt(ErlNifEnv* env, int argc, const ERL_NIF_TERM
 
 static ERL_NIF_TERM hashpw(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
-    char pw[1024];
-    char salt[1024];
-    char encrypted[BCRYPT_HASHSPACE];
-
-    (void)memset(&pw, '\0', sizeof(pw));
-    (void)memset(&salt, '\0', sizeof(salt));
-
-    if (enif_get_string(env, argv[0], pw, sizeof(pw), ERL_NIF_LATIN1) < 1)
-        return enif_make_badarg(env);
-
-    if (enif_get_string(env, argv[1], salt, sizeof(salt), ERL_NIF_LATIN1) < 1)
-        return enif_make_badarg(env);
-
-    if (bcrypt(pw, salt, encrypted, sizeof(encrypted)) ||
-            0 == strcmp(encrypted, ":")) {
-        return enif_make_badarg(env);
-    }
-
-    return enif_make_string(env, encrypted, ERL_NIF_LATIN1);
+    return enif_schedule_nif(env, "bcrypt_init", 0, bcrypt_init, 2, argv);
 }
 
 static ErlNifFunc bcrypt_nif_funcs[] =


### PR DESCRIPTION
I have reworked the bcrypt C code to fix the issue seen in #8.  These changes break up the longest running parts of the bcrypt algorithm in order to yield execution back to the Erlang VM every millisecond or so.  I have verified the fix manually using the [bitwise method](https://github.com/vinoski/bitwise#long-scheduling).

There are a couple of concerns with these changes:
* I have done my best to maintain the security of the original implementation, and there are no obvious bugs or vulnerabilities.  However, writing C code is difficult, and writing *secure* C code is doubly so.  If you know of anyone who is familiar with cryptography or writing complex NIFs in general, I would love for them to take a close look at my implementation.
* In order to make bcrypt regularly relinquish control back to Erlang, the code was modified to the point that keeping the C source up-to-date with the OpenSSL implementation will be more difficult.  I don't know if this fix is worth the extra work for maintainers going forward.

I see that you have started your own pure Elixir implementation of bcrypt.  In the long run, that may be the best solution.  In which case this code may be used as a temporary fix for #8, or you might want to pull it into a separate branch to compare the efficiency of the native code with a pure Elixir implementation when it is completed.

Thanks!