### PR TITLE
Fix compilation on Windows

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -12,7 +12,6 @@ CFLAGS = /O2 /EHsc /I"$(BCRYPT_PATH)"
 
 NIF_SRC=\
 	c_src\bcrypt_nif.c\
-	c_src\bcrypt.c\
 	c_src\blowfish.c
 
 all: comeonin

--- a/c_src/bcrypt_nif.c
+++ b/c_src/bcrypt_nif.c
@@ -36,7 +36,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 
 #include "erl_nif.h"
 #include "erl_blf.h"


### PR DESCRIPTION
2 small fixes I needed to apply before being able to compile the NIFs on Windows 7 64 bits with Visual Studio 2013.