### PR TITLE
Document missing installation dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Elixir version 1.0 or later and Erlang/OTP version 17.0 or later.
 
 You also need to have a C compiler, such as `gcc`, installed.
 
+Ubuntu and Debian-based systems can get `gcc` and `make` by installing `build-essential` package. Also `erlang-dev` may be needed if not included in your Erlang/OTP version.
+
 For users of Ubuntu, or any other Debian-based distro, we recommend downloading
 erlang from [erlang solutions](https://www.erlang-solutions.com/downloads/download-erlang-otp),
 as the version of erlang in the repositories is usually quite old.

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Mix.Tasks.Compile.Comeonin do
     `mix deps.compile comeonin` from the `Developer Command Prompt`. If
     you are using 64-bit erlang, you might need to run the command
     `vcvarsall.bat amd64` before running `mix deps.compile`. Further
-    information can be found at 
+    information can be found at
     (https://msdn.microsoft.com/en-us/library/x4d2c09s.aspx).
 
     Mac OS X: You need to have gcc and make installed. Try running the
@@ -41,8 +41,9 @@ defmodule Mix.Tasks.Compile.Comeonin do
     are not installed, you will be prompted to install them.
 
     Linux: You need to have gcc and make installed. If you are using
-    Ubuntu or any other Debian-based system, install the package
-    `build essential`.
+    Ubuntu or any other Debian-based system, install the packages
+    `build-essential`. Also install `erlang-dev` package if not
+    included in your Erlang/OTP version.
 
     """
   end


### PR DESCRIPTION
> Erlang/OTP 17, Elixir 1.0.4, Ubuntu 15.04

I'm was getting the following error while running `mix do deps.get, compile`:

```
mix.exs:24: Mix.Tasks.Compile.Comeonin.handle_error/0
    (elixir) lib/enum.ex:977: anonymous fn/3 in Enum.map/2
    (elixir) lib/enum.ex:1261: Enum."-reduce/3-lists^foldl/2-0-"/3
    (elixir) lib/enum.ex:977: Enum.map/2
    (mix) lib/mix/tasks/compile.all.ex:15: Mix.Tasks.Compile.All.run/1
    (mix) lib/mix/tasks/compile.ex:64: Mix.Tasks.Compile.run/1
    (mix) lib/mix/tasks/deps.compile.ex:105: anonymous fn/2 in Mix.Tasks.Deps.Compile.do_mix/1
    (mix) lib/mix/project.ex:196: Mix.Project.in_project/4
```

I got `gcc` and `make` via `build-essential` pkg but still getting the same error.

I found installing `erlang-dev` pkg solved this issue. This PR aims to document this in case someone else face the same issue in the future.