### PR TITLE
Add failing test, nil inputs on Bcrypt.checkpw/2

### DIFF
--- a/lib/comeonin/bcrypt.ex
+++ b/lib/comeonin/bcrypt.ex
@@ -71,6 +71,9 @@ defmodule Comeonin.Bcrypt do
 
   The check is performed in constant time to avoid timing attacks.
   """
+  def checkpw(password, hash) when is_nil(password) or is_nil(hash) do
+    false
+  end
   def checkpw(password, hash) do
     hashpw(:binary.bin_to_list(password), :binary.bin_to_list(hash))
     |> Tools.secure_check(hash)

--- a/test/bcrypt_test.exs
+++ b/test/bcrypt_test.exs
@@ -16,7 +16,7 @@ defmodule Comeonin.BcryptTest do
     assert Bcrypt.checkpw(wrong2, hash) == false
     assert Bcrypt.checkpw(wrong3, hash) == false
   end
- 
+
   test "Openwall Bcrypt tests" do
    [{"U*U",
      "$2a$05$CCCCCCCCCCCCCCCCCCCCC.",
@@ -158,5 +158,11 @@ defmodule Comeonin.BcryptTest do
     assert String.starts_with?(Bcrypt.gen_salt, prefix)
     assert String.starts_with?(Bcrypt.hashpwsalt("password"), prefix)
     Application.delete_env(:comeonin, :bcrypt_log_rounds)
+  end
+
+  test "nil inputs to checkpw" do
+    assert Bcrypt.checkpw(nil, nil) == false
+    assert Bcrypt.checkpw("password", nil) == false
+    assert Bcrypt.checkpw(nil, "somehashstored") == false
   end
 end


### PR DESCRIPTION
Added failing spec and fix. Erlang `:binary.bin_to_list` doesn't allow nil inputs which causes checkpw to fail.

```
** (ArgumentError) argument error
     stacktrace:
       (stdlib) :binary.bin_to_list(nil)
       (comeonin) lib/comeonin/bcrypt.ex:78: Comeonin.Bcrypt.checkpw/2
       test/bcrypt_test.exs:164
```

There're scenarios when `checkpw/2` gets a nil password, breaking `Comeonin`
As an example Phoenix `plug :scrub_params` sanitize empty string as nil values with leads to the same error.