### PR TITLE
Call Mix.Project.build_structure after compiling c_src

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,6 +16,8 @@ defmodule Mix.Tasks.Compile.Comeonin do
 
     if System.find_executable(exec) do
       build(exec, args)
+      Mix.Project.build_structure
+      :ok
     else
       nocompiler_error(exec)
     end


### PR DESCRIPTION
Because the compiler changes the priv directory, we need to notify
Mix to rebuild the project structure under _build, copying the new
priv files.

In Elixir v1.0, Elixir called build_structure multiple times, which
was not efficient. Elixir v1.1 calls it once before running compilers,
so compilers writing to priv must adjust.

Closes #40.