### PR TITLE
Use gettext for I18N

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -22,3 +22,6 @@ use Mix.Config
 # here (which is why it is important to import them last).
 #
 #     import_config "#{Mix.env}.exs"
+
+# The value of the default locale for Gettext module
+config :comeonin, Comeonin.Gettext, default_locale: "en"

--- a/lib/comeonin.ex
+++ b/lib/comeonin.ex
@@ -79,6 +79,7 @@ defmodule Comeonin do
   """
 
   import Comeonin.Password
+  import Comeonin.Gettext
   alias Comeonin.Config
 
   @doc """
@@ -225,6 +226,7 @@ defmodule Comeonin do
       {:error, "The password should be at least 8 characters long."}
 
   """
+
   def create_user(user_params, opts \\ [])
   def create_user(%{password: password} = user_params, opts) do
     Map.delete(user_params, :password) |> create_map(password, :password_hash, opts)
@@ -233,7 +235,7 @@ defmodule Comeonin do
     Map.delete(user_params, "password") |> create_map(password, "password_hash", opts)
   end
   def create_user(_, _) do
-    {:error, ~s(We could not find the password. The password key should be either :password or "password".)}
+    {:error, gettext "We could not find the password. The password key should be either :password or \"password\"."}
   end
 
   defp create_map(user_params, password, hash_key, opts) do

--- a/lib/comeonin/bcrypt.ex
+++ b/lib/comeonin/bcrypt.ex
@@ -37,6 +37,7 @@ defmodule Comeonin.Bcrypt do
   alias Comeonin.Bcrypt.Base64
   alias Comeonin.Config
   alias Comeonin.Tools
+  import Comeonin.Gettext
 
   @on_load {:init, 0}
 
@@ -65,11 +66,11 @@ defmodule Comeonin.Bcrypt do
     if byte_size(salt) == 29 do
       hashpw(:binary.bin_to_list(password), :binary.bin_to_list(salt))
     else
-      raise ArgumentError, message: "The salt is the wrong length."
+      raise ArgumentError, message: gettext "The salt is the wrong length."
     end
   end
   def hashpass(_password, _salt) do
-    raise ArgumentError, message: "Wrong type. The password and salt need to be strings."
+    raise ArgumentError, message: gettext "Wrong type. The password and salt need to be strings."
   end
 
   @doc """
@@ -93,7 +94,7 @@ defmodule Comeonin.Bcrypt do
     |> Tools.secure_check(hash)
   end
   def checkpw(_password, _hash) do
-    raise ArgumentError, message: "Wrong type. The password and hash need to be strings."
+    raise ArgumentError, message: gettext "Wrong type. The password and hash need to be strings."
   end
 
   @doc """
@@ -145,7 +146,7 @@ defmodule Comeonin.Bcrypt do
     {Base64.decode(salt), bsl(1, log_rounds)}
   end
   defp prepare_keys(_, _) do
-    raise ArgumentError, message: "Wrong number of rounds."
+    raise ArgumentError, message: gettext "Wrong number of rounds."
   end
 
   defp expand_keys(state, _key, _key_len, _salt, 0), do: state

--- a/lib/comeonin/bcrypt/base64.ex
+++ b/lib/comeonin/bcrypt/base64.ex
@@ -4,6 +4,7 @@ defmodule Comeonin.Bcrypt.Base64 do
   """
 
   use Bitwise
+  import Comeonin.Gettext
 
   @decode_map {:bad,:bad,:bad,:bad,:bad,:bad,:bad,:bad,:bad,:ws,:ws,:bad,:bad,:ws,:bad,:bad,
     :bad,:bad,:bad,:bad,:bad,:bad,:bad,:bad,:bad,:bad,:bad,:bad,:bad,:bad,:bad,:bad,
@@ -94,6 +95,6 @@ defmodule Comeonin.Bcrypt.Base64 do
 
   defp b64d_ok(val) when is_integer(val), do: val
   defp b64d_ok(val) do
-    raise ArgumentError, message: "invalid character: #{val}"
+    raise ArgumentError, message: gettext "invalid character: %{val}", val: val
   end
 end

--- a/lib/comeonin/gettext.ex
+++ b/lib/comeonin/gettext.ex
@@ -1,0 +1,7 @@
+defmodule Comeonin.Gettext do
+  @moduledoc """
+  Module to provide `gettext` function for i18n.
+  See the documentation for `elixir-lang/gettext` for more details.
+  """
+  use Gettext, otp_app: :comeonin
+end

--- a/lib/comeonin/password.ex
+++ b/lib/comeonin/password.ex
@@ -77,6 +77,7 @@ defmodule Comeonin.Password do
   """
 
   import Comeonin.Password.Common
+  import Comeonin.Gettext
 
   @alpha Enum.concat ?A..?Z, ?a..?z
   @alphabet '!#$%&\'()*+,-./:;<=>?@[\\]^_{|}~"' ++ @alpha ++ '0123456789'
@@ -104,7 +105,7 @@ defmodule Comeonin.Password do
     rand_password(len) |> to_string |> ensure_strong(len)
   end
   def gen_password(_) do
-    raise ArgumentError, message: "The password should be at least 8 characters long."
+    raise ArgumentError, message: gettext "The password should be at least %{min_len} characters long.", min_len: 8
   end
 
   defp rand_password(len) do
@@ -196,7 +197,7 @@ defmodule Comeonin.Password do
   end
 
   defp pass_length?(word_len, min_len) when word_len < min_len do
-    "The password should be at least #{min_len} characters long."
+    gettext "The password should be at least %{min_len} characters long.", min_len: min_len
   end
   defp pass_length?(_, _), do: true
 
@@ -204,13 +205,13 @@ defmodule Comeonin.Password do
     if :binary.match(word, @digits) != :nomatch and :binary.match(word, @punc) != :nomatch do
       true
     else
-      "The password should contain at least one number and one punctuation character."
+      gettext "The password should contain at least one number and one punctuation character."
     end
   end
 
   defp not_common?(password, word_len) when word_len < 13 do
     if password |> String.downcase |> common_password?(word_len) do
-      "The password you have chosen is weak because it is easy to guess. Please choose another one."
+      gettext "The password you have chosen is weak because it is easy to guess. Please choose another one."
     else
       true
     end

--- a/lib/comeonin/pbkdf2.ex
+++ b/lib/comeonin/pbkdf2.ex
@@ -32,6 +32,7 @@ defmodule Comeonin.Pbkdf2 do
   alias Comeonin.Pbkdf2.Base64
   alias Comeonin.Config
   alias Comeonin.Tools
+  import Comeonin.Gettext
 
   @max_length bsl(1, 32) - 1
   @salt_length 16
@@ -47,7 +48,7 @@ defmodule Comeonin.Pbkdf2 do
     :crypto.strong_rand_bytes(salt_length)
   end
   def gen_salt(_) do
-    raise ArgumentError, message: "The salt is the wrong length."
+    raise ArgumentError, message: gettext "The salt is the wrong length."
   end
 
   @doc """
@@ -57,7 +58,7 @@ defmodule Comeonin.Pbkdf2 do
     if is_binary(salt) do
       pbkdf2(password, salt, rounds, 64) |> format(salt, rounds)
     else
-      raise ArgumentError, message: "Wrong type. The salt needs to be a string."
+      raise ArgumentError, message: gettext "Wrong type. The salt needs to be a string."
     end
   end
 
@@ -88,7 +89,7 @@ defmodule Comeonin.Pbkdf2 do
     |> Tools.secure_check(hash)
   end
   def checkpw(_password, _hash) do
-    raise ArgumentError, message: "Wrong type. The password and hash need to be strings."
+    raise ArgumentError, message: gettext "Wrong type. The password and hash need to be strings."
   end
 
   @doc """
@@ -108,7 +109,7 @@ defmodule Comeonin.Pbkdf2 do
     pbkdf2(password, salt, rounds, length, 1, [], 0)
   end
   defp pbkdf2(_password, _salt, _rounds, _length) do
-    raise ArgumentError, message: "The salt is the wrong length."
+    raise ArgumentError, message: gettext "The salt is the wrong length."
   end
 
   defp pbkdf2(_password, _salt, _rounds, max_length, _block_index, acc, length)

--- a/mix.exs
+++ b/mix.exs
@@ -4,6 +4,7 @@ defmodule Mix.Tasks.Compile.Comeonin do
   def run(_) do
     if Mix.env != :test, do: File.rm_rf("priv")
     File.mkdir("priv")
+    File.cp_r("po", "priv/gettext")
     {exec, args} = case :os.type do
       {:win32, _} ->
         {"nmake", ["/F", "Makefile.win", "priv\\bcrypt_nif.dll"]}
@@ -118,19 +119,20 @@ defmodule Comeonin.Mixfile do
       description: @description,
       package: package,
       source_url: "https://github.com/elixircnx/comeonin",
-      compilers: [:comeonin, :elixir, :app],
+      compilers: [:comeonin, :gettext, :elixir, :app],
       deps: deps
     ]
   end
 
   def application do
-    [applications: [:crypto, :logger]]
+    [applications: [:crypto, :gettext, :logger]]
   end
 
   defp deps do
     [
       {:earmark, "~> 0.1", only: :dev},
-      {:ex_doc,  "~> 0.10", only: :dev}
+      {:ex_doc,  "~> 0.10", only: :dev},
+      {:gettext, "~> 0.7"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,3 @@
 %{"earmark": {:hex, :earmark, "0.1.17"},
-  "ex_doc": {:hex, :ex_doc, "0.10.0"}}
+  "ex_doc": {:hex, :ex_doc, "0.10.0"},
+  "gettext": {:hex, :gettext, "0.7.0"}}

--- a/po/ja_JP/LC_MESSAGES/default.po
+++ b/po/ja_JP/LC_MESSAGES/default.po
@@ -1,0 +1,29 @@
+msgid "The password should be at least %{min_len} characters long."
+msgstr "パスワードは%{min_len}文字以上である必要があります。"
+
+msgid "The password should contain at least one number and one punctuation character."
+msgstr "パスワードは1字以上の数字と記号が含まれている必要があります。"
+
+msgid "The password you have chosen is weak because it is easy to guess. Please choose another one."
+msgstr "入力されたパスワードは推測が容易で強度が不十分です。違うものを指定してください。"
+
+msgid "The salt is the wrong length."
+msgstr "ソルトの長さが正しくありません。"
+
+msgid "We could not find the password. The password key should be either :password or \"password\"."
+msgstr "パスワードが見つかりません。キーが:passwordか\"password\"である必要があります。"
+
+msgid "Wrong number of rounds."
+msgstr "不正なラウンド数です。"
+
+msgid "Wrong type. The password and hash need to be strings."
+msgstr "不正な型です。パスワードとハッシュは文字列である必要があります。"
+
+msgid "Wrong type. The password and salt need to be strings."
+msgstr "不正な型です。パスワードとソルトは文字列である必要があります。"
+
+msgid "Wrong type. The salt needs to be a string."
+msgstr "不正な型です。ソルトは文字列である必要があります。"
+
+msgid "invalid character: %{val}"
+msgstr "不正な文字です: %{val}"

--- a/test/gettext_test.exs
+++ b/test/gettext_test.exs
@@ -1,0 +1,20 @@
+defmodule GettextTest do
+  use ExUnit.Case, async: true
+  import Comeonin.Gettext
+
+  test "gettext works with Japanese po file" do
+    Gettext.put_locale(Comeonin.Gettext, "ja_JP")
+    text =  gettext "The password should be at least %{min_len} characters long.", min_len: 8
+    assert text == "パスワードは8文字以上である必要があります。"
+  end
+
+  test "gettext returns Japanese message if locale is ja_JP" do
+    Gettext.put_locale(Comeonin.Gettext, "ja_JP")
+
+    assert Comeonin.create_hash("password") ==
+    {:error, "パスワードは1字以上の数字と記号が含まれている必要があります。"}
+
+    assert Comeonin.create_hash("pa$w0rd") ==
+    {:error, "パスワードは8文字以上である必要があります。"}
+  end
+end


### PR DESCRIPTION
Hello,
I use this library for a project with Phoenix and it would be better if `comeonin` return a non-English (e.g.  Japanese) message when an error occurs. I try using [elixir-lang/gettext](https://github.com/elixir-lang/gettext). I18N maybe boring but is useful for some people. 
What do you think about I18N support?
