### PR TITLE
Improved formatting of Step 4 in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,12 @@ page in the wiki for details.
 or pbkdf2, rounds so it does not slow down your test suite. If you have a `config/test.exs`,
 you should add (depending on which algorithm you are using):
 
-    config :comeonin, :bcrypt_log_rounds, 4
-    config :comeonin, :pbkdf2_rounds, 1
+  ```elixir  
+  config :comeonin, :bcrypt_log_rounds, 4
+  config :comeonin, :pbkdf2_rounds, 1
+  ```
 
-NB: do not use the above values in production.
+  NB: do not use the above values in production.
 
 ## Usage
 


### PR DESCRIPTION
The current formatting for Step 4 of the install instructions has been hard for me to read. I just improved the formatting a little, and put the config values in a fenced code block.