### PR TITLE
Do not append to LDFLAGS if cross compiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,18 @@ CFLAGS = -g -O3 -Wall
 ERLANG_PATH = $(shell erl -eval 'io:format("~s", [lists:concat([code:root_dir(), "/erts-", erlang:system_info(version), "/include"])])' -s init stop -noshell)
 CFLAGS += -I$(ERLANG_PATH)
 CFLAGS += -Ic_src
+ifneq ($(CROSSCOMPILE),)
+    # crosscompiling
+    CFLAGS += -fPIC
+else
+    # not crosscompiling
+    ifneq ($(OS),Windows_NT)
+        CFLAGS += -fPIC
 
-ifneq ($(OS),Windows_NT)
-	CFLAGS += -fPIC
-
-	ifeq ($(shell uname),Darwin)
-		LDFLAGS += -dynamiclib -undefined dynamic_lookup
-	endif
+        ifeq ($(shell uname),Darwin)
+            LDFLAGS += -dynamiclib -undefined dynamic_lookup
+        endif
+    endif
 endif
 
 NIF_SRC=\


### PR DESCRIPTION
When building nerves applications on a mac we do not need to append to the LDFLAGS