### PR TITLE
prevent the module from being autoloaded after compilation

### DIFF
--- a/lib/comeonin/bcrypt.ex
+++ b/lib/comeonin/bcrypt.ex
@@ -39,6 +39,7 @@ defmodule Comeonin.Bcrypt do
   alias Comeonin.Config
   alias Comeonin.Tools
 
+  @compile {:autoload, false}
   @on_load {:init, 0}
 
   def init do


### PR DESCRIPTION
This will prevent the compiler from autoloading the module when using the Elixir 1.2.2 compiler. It is safe for all version of Elixir