### PR TITLE
Fix warnings per elixir 1.3-dev

### DIFF
--- a/lib/comeonin/bcrypt.ex
+++ b/lib/comeonin/bcrypt.ex
@@ -166,7 +166,7 @@ defmodule Comeonin.Bcrypt do
 
   defp bcrypt(key, salt, prefix, log_rounds) when prefix in ['2b', '2a'] do
     key_len = length(key) + 1
-    if prefix == '2b' and key_len > 73, do: key_len = 73
+    key_len = if prefix == '2b' and key_len > 73, do: 73
     {salt, rounds} = prepare_keys(salt, List.to_integer(log_rounds))
     bf_init(key, key_len, salt)
     |> expand_keys(key, key_len, salt, rounds)


### PR DESCRIPTION
These should be gone now:
```
warning: the variable "key_len" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/comeonin/bcrypt.ex:171

warning: the variable "key_len" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/comeonin/bcrypt.ex:172
```